### PR TITLE
added dhcp staticmap

### DIFF
--- a/tasks/dhcpd.yml
+++ b/tasks/dhcpd.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: dhcpd
   delegate_to: localhost
   xml:
@@ -9,4 +10,16 @@
   with_subelements:
     - "{{ opn_dhcpd | default([]) }}"
     - settings
+
+- name: dhcpd static map
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/dhcpd/{{ item.0.if }}/staticmap[mac/text()="{{ item.0.mac }}"]/{{ item.1.key }}
+    value: "{{ item.1.value }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_dhcpd_staticmap | default([]) }}"
+    - settings
+
 ...


### PR DESCRIPTION
added support for dhcp static maps...
in this case there are 2 keys required to form the XPATH (interface and mac address), which does not quite follow the patterns I have seen, but does not break the concept much either:

```
opn_dhcpd_staticmap:
  - mac:  00:00:00...
    if: lan 
    settings:
      - key: descr
        value: Control PC
      - key: hostname
        value: host1
      - key: ipaddr
        value: 10.1.0.3
  - mac:  00:00:00...
    if: lan 
    settings:
      - key: descr
        value: Control PC2
      - key: hostname
        value: host2
      - key: ipaddr
        value: 10.1.0.4
```