### PR TITLE
implemented new aliases

### DIFF
--- a/tasks/alias.yml
+++ b/tasks/alias.yml
@@ -3,10 +3,24 @@
   delegate_to: localhost
   xml:
     path: /tmp/config-{{ inventory_hostname }}.xml
-    xpath: /opnsense/aliases/alias[name/text()="{{ item.0.name }}"]/{{ item.1.key }}
+    xpath: /opnsense/OPNsense/Firewall/Alias/aliases/alias[@uuid="{{ item.0.uuid }}"]/{{ item.1.key }}
     value: "{{ item.1.value }}"
     pretty_print: yes
   with_subelements:
     - "{{ opn_alias | default([]) }}"
     - settings
+  when: item.1.value is defined
+
+- name: multivalue aliases
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/OPNsense/Firewall/Alias/aliases/alias[@uuid="{{ item.0.uuid }}"]/{{ item.1.key }}
+    value: "{{ item.1.list | join('\n') }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_alias | default([]) }}"
+    - settings
+  when: item.1.list is defined
+
 ...


### PR DESCRIPTION
this PR updates the current alias module to generate compatible XML with the latest Alias module

Note that the alias now have different requirements and therefore there are changes in the YML used for this.

Example of new Aliases YML:

```
opn_alias:

  - uuid: 6e319c0e-f016-11e9-b3fd-1002b50d9337
    settings:
      - key: name
        value: private
      - key: type
        value: network
      - key: content
        list:
          - 10.0.0.0/8
          - 172.16.0.0/12
          - 192.168.0.0/16
      - key: enabled
        value: "1"

  - uuid: b1c3a4b4-f019-11e9-8d2c-1002b50d9337
    settings:
      - key: name
        value: host
      - key: type
        value: host
      - key: content
        value: host.com
      - key: enabled
        value: "1"
      - key: description
        value: Our Host
```

Main differences are that an UUID is required and that support for multiple values is provided.