### PR TITLE
fixed and empty element left behind when first bridge is created

### DIFF
--- a/tasks/bridges.yml
+++ b/tasks/bridges.yml
@@ -10,3 +10,14 @@
     - "{{ opn_bridges }}"
     - settings
   when: opn_bridges is defined
+
+
+# remove the default empty <bridged/> node remains after configuring the first one
+
+- name: bridges - remove default empty node
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/bridges/bridged[not(node())]
+    state: absent
+  when: opn_bridges is defined


### PR DESCRIPTION
fixes a minor issue. 

The default config file contains an tempty <bridge/> element, and when the first bridge is added the element is left behind, which confuses OPNSense.

This patch will remove the element with empty content. The same pattern is applicable to many other configurations.