### PR TITLE
allows for base64 fields to be used

### DIFF
--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: user
   delegate_to: localhost
   xml:
@@ -9,6 +10,19 @@
   with_subelements:
     - "{{ opn_user | default([]) }}"
     - settings
+  when: item.1.value is defined
+
+- name: b64 user fields
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/system/user[name/text()="{{ item.0.name }}"]/{{ item.1.key }}
+    value: "{{ item.1.b64_value | b64encode }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_user | default([]) }}"
+    - settings
+  when: item.1.b64_value is defined
 
 - name: user - nextid
   delegate_to: localhost


### PR DESCRIPTION
Some OPNSense configuration files are encoded in Base64,
In this particular case, authorized keys need to be encoded in base64.

This patch allows for a b64_value: element to be used, and it will be converted to base64 automatically.

In particular it is possible to do:
```
settings:
  - value: authorized_keys
    b64_value: |
      key 1 ..............
      key 2 ............
      key N as copied/pasted from authorized_keys file
```

this makes management of this file easier