### PR TITLE
adds nat port forward, fixes empty rules left behind on first addition

### DIFF
--- a/tasks/nat.yml
+++ b/tasks/nat.yml
@@ -18,4 +18,37 @@
   with_subelements:
     - "{{ opn_nat | default([]) }}"
     - settings
+
+# remove the default empty <rule/> node remains after configuring the first one
+
+- name: nat - remove default empty node
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/nat/outbound/rule[not(node())]
+    state: absent
+  when: opn_nat is defined
+
+- name: nat - port forward
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/nat/rule[descr/text()="{{ item.0.descr }}"]/{{ item.1.key }}
+    value: "{{ item.1.value }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_nat_port_forward | default([]) }}"
+    - settings
+
+
+# remove the default empty <rule/> node remains after configuring the first one
+
+- name: nat - remove default empty node
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/nat/rule[not(node())]
+    state: absent
+  when: opn_nat_port_forward is defined
+
 ...


### PR DESCRIPTION
Enables the creation of port forwarding rules

like for example: 

```
opn_nat_port_forward:
  - descr: Web Access
    settings:
      # Interface
      - key: interface
        value: wan
      # Protocol
      - key: ipprotocol
        value: inet
      - key: protocol
        value: tcp
      # Source
      - key: source/any
        value: 1
      # Destination
      - key: destination/network
        value: wanip
      - key: destination/port
        value: 443
      # Target
      - key: target
        value: web_server
      - key: local-port
        value: 443

```