### PR TITLE
adds several new features: CAs, AuthenticationServers, tunnables, VPN…

### DIFF
--- a/tasks/authservers.yml
+++ b/tasks/authservers.yml
@@ -1,0 +1,24 @@
+---
+
+- name: authservers - authentication servers
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/system/authserver[refid/text()="{{ item.0.refid }}"]/{{ item.1.key }}
+    value: "{{ item.1.value }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_authservers }}"
+    - settings
+  when: opn_authservers is defined
+
+# remove the default empty <authserver/> node remains after configuring the first one
+
+- name: authserver - remove default empty node
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/system/authserver[not(node())]
+    state: absent
+  when: opn_authservers is defined
+...

--- a/tasks/ca.yml
+++ b/tasks/ca.yml
@@ -1,0 +1,63 @@
+---
+
+- name: CAs - certificate authorities
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/ca[refid/text()="{{ item.0.refid }}"]/{{ item.1.key }}
+    value: "{{ item.1.value }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_cas | default([])  }}"
+    - settings
+  when: item.1.value is defined
+
+- name: b64 ca fields
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/ca[refid/text()="{{ item.0.refid }}"]/{{ item.1.key }}
+    value: "{{ item.1.b64_value | b64encode }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_cas | default([]) }}"
+    - settings
+  when: item.1.b64_value is defined
+
+
+# remove the default empty <ca/> node remains after configuring the first one
+
+- name: CAs - remove default empty node
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/ca[not(node())]
+    state: absent
+  when: opn_cas is defined
+
+- name: certificates 
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/cert[refid/text()="{{ item.0.refid }}"]/{{ item.1.key }}
+    value: "{{ item.1.value }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_certs | default([])  }}"
+    - settings
+  when: item.1.value is defined
+
+- name: b64 certificate fields
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/cert[refid/text()="{{ item.0.refid }}"]/{{ item.1.key }}
+    value: "{{ item.1.b64_value | b64encode }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_certs | default([]) }}"
+    - settings
+  when: item.1.b64_value is defined
+
+
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,22 @@
   include: general.yml
   tags: general
 
+- name: sysctl
+  include: sysctl.yml
+  tags: sysctl
+
+- name: authservers
+  include: authservers.yml
+  tags: authservers
+
+- name: CAs
+  include: ca.yml
+  tags: ca
+
+- name: VPN
+  include: vpn.yml
+  tags: vpn
+
 - name: interfaces
   include: interfaces.yml
   tags: interfaces
@@ -85,6 +101,11 @@
     backup: yes
   register: config
   tags: copy
+
+- name: clean,safe delete
+  delegate_to: localhost
+  shell: srm /tmp/config-{{ inventory_hostname }}.xml
+  tags: clean
 
 - name: reload
   command: "{{ item }}"

--- a/tasks/sysctl.yml
+++ b/tasks/sysctl.yml
@@ -1,0 +1,13 @@
+---
+
+- name: sysctl - system tunables
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/sysctl/item[tunable/text()="{{ item.tunable }}"]/value
+    value: "{{ item.value }}"
+    pretty_print: yes
+  loop: "{{ opn_sysctl }}"
+  when: opn_sysctl is defined
+
+...

--- a/tasks/vpn.yml
+++ b/tasks/vpn.yml
@@ -1,0 +1,38 @@
+---
+
+- name: OpenVPN Servers
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/openvpn/openvpn-server[vpnid/text()="{{ item.0.vpnid }}"]/{{ item.1.key }}
+    value: "{{ item.1.value }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_openvpn_servers | default([])  }}"
+    - settings
+  when: item.1.value is defined
+
+- name: b64 OpenVPN fields
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/openvpn/openvpn-server[vpnid/text()="{{ item.0.vpnid }}"]/{{ item.1.key }}
+    value: "{{ item.1.b64_value | b64encode }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_openvpn_servers | default([]) }}"
+    - settings
+  when: item.1.b64_value is defined
+
+# remove the default empty <openvpn-server/> node remains after configuring the first one
+
+- name: OpenVPN Servers - remove default empty node
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/openvpn/openvpn-server[not(node())]
+    state: absent
+  when: opn_openvpn_servers is defined
+
+
+...


### PR DESCRIPTION
… and secure temporal file cleaning as per #12

It adds several new Features:

**Certificate Authorities**

Possible to add certificate authorities and certificates, with the possibility to use base64 values, like:

```
opn_cas:
  - refid: 5da98cfba4d6b
    settings:
      - key: descr
        value: VPNCA
      - key: crt
        b64_value: |
          -----BEGIN CERTIFICATE-----
          MIIF3TCCA8WgAwIBAgIBADANBgkqhkiG9w0BAQsFADCBiDELMAkGA1UEBhMCU0Ux
          DT2oMeiBLUkk6BH+1AE19xA6YpxvGjIcx3MzDf6ua3WIEsloX0cHwJyuLsEQlEES
          R1S40fwr+Bw8vVBd/dcI4hNeHggwHAlcjDbJCnfxlk7WnQvWFJxIdcw2z8uEH0Fd
          5pgGcU6PRmwgraHK6+m6JWk=
          -----END CERTIFICATE-----
      - key: prv
        b64_value: !vault |
          $ANSIBLE_VAULT;1.1;AES256
          66653136366639373062623364616435373736663963343939343734313835636632376437393838
          6162353834623763343036346434656635386233326165390a336233396665643735646533646130
          38396630363536643237376535386161643736313032356639363834636266393566363038366233
          38313964366232353233
      - key: serial
        value: "1"

opn_certs:
  - refid: 5da9c397c6dcd
    settings:
      - key: caref
        value: 5da98cfba4d6b
      - key: descr
        value: VPN Server
      - key: crt
        b64_value: |
          -----BEGIN CERTIFICATE-----
          MIIG8DCCBNigAwIBAgIBATANBgkqhkiG9w0BAQsFADCBiDELMAkGA1UEBhMCU0Ux
          EzARBgNVBAgMClZhbGxlbnR1bmExEzARBgNVBAcMClZhbGxlbnR1bmExFTATBgNV
          BAoMDFZhbGxldGVjaCBBQjEeMBwGCSqGSIb3DQEJARYPaXRAdmFsbGV0ZWNoLmV1
          d5gGmw==
          -----END CERTIFICATE-----
      - key: prv
        b64_value: !vault |
          $ANSIBLE_VAULT;1.1;AES256
          38636138646235643862386134616338383037333930386130326561663134616637353531343130
          34666365386133663932

```

sample keys and certificates are fictitious. Keys can be encrypted with the vault.
Certificates and CAs can later be refered from the VPN settings

**Authentication Servers**

Allows for configuration of authentication servers which later can be referred from the VPN
 
```
opn_authservers:
  - refid: 5da98060209f8
    settings:
      - key: name
        value: LocalOTP
      - key: type
        value: totp
      - key: otpLength
        value: "6"
      - key: passwordFirst
        value: "1"
```
**VPN Servers**

The possibility to add OpenVPN Servers as:

```

opn_openvpn_servers:
  - vpnid: 1
    settings:
      # General
      - key: description
        value: OPNSense VPN Server
      - key: mode
        value: server_user
      - key: verbosity_level
        value: "1"
      - key: custom_options
        value: |
          push "route 10.1.0.0 255.255.0.0"
      # Networking
      - key: interface
        value: wan
      - key: protocol
        value: UDP
      - key: dev_mode
        value: tun
      - key: local_port
        value: 1194
      - key: tunnel_network
        value: 192.168.0.0/24
      - key: netbios_ntype
        value: "0"
      - key: no_tun_ipv6
        value: "yes"
      - key: compression
        value: adaptive
      # Authentication
      - key: authmode
        value: LocalOTP
      - key: reneg-sec
        value: "0"
      # Cryptography
      - key: crypto
        value: AES-256-CBC
      - key: digest
        value: SHA512
      - key: engine
        value: none
      - key: pool_enable
        value: "yes"
      - key: tls
        b64_value: !vault |
          $ANSIBLE_VAULT;1.1;AES256
          61303435353662316632366130383365643035366330383136333762646437336534373165323938
34633636366434663836366661366265343730326235343461336264336439366230616436346461
          3138643339383732303534613531346131336666653561396364

      - key: caref
        value: 5da98cfba4d6b
      - key: certref
        value: 5da9c397c6dcd
      - key: dh_length
        value: 4096
      - key: cert_depth
        value: 1

```

**Sysctl**

The possibility to add tunables as:

```
opn_sysctl:
  - tunable: net.link.bridge.pfil_member
    value: "0"
  - tunable: net.link.bridge.pfil_bridge
    value: "1"
```

**Safe CleanUp**
Temporal configuration files will be deleted with srm, and fixes issue #12


