### PR TITLE
allow VLANs to be configured on multiple interfaces

### DIFF
--- a/tasks/interfaces.yml
+++ b/tasks/interfaces.yml
@@ -29,7 +29,7 @@
   xml:
     path: /tmp/config-{{ inventory_hostname }}.xml
     xpath: /opnsense/interfaces/{{ item.0.interface }}/if
-    value: "{{ opn_interfaces_vlan_parent_interface }}_vlan{{ item.0.vlan }}"
+    value: "{{ item.0.vlan_parent_interface | default(opn_interfaces_vlan_parent_interface) }}_vlan{{ item.0.vlan }}"
     pretty_print: yes
   with_subelements:
     - "{{ opn_interfaces_specific }}"

--- a/tasks/vlans.yml
+++ b/tasks/vlans.yml
@@ -14,7 +14,7 @@
   xml:
     path: /tmp/config-{{ inventory_hostname }}.xml
     xpath: /opnsense/vlans/vlan[tag/text()="{{ item.0.tag }}"]/if
-    value: "{{ opn_interfaces_vlan_parent_interface }}"
+    value: "{{ item.0.vlan_parent_interface | default(opn_interfaces_vlan_parent_interface) }}"
     pretty_print: yes
   with_subelements:
     - "{{ opn_vlans }}"
@@ -25,7 +25,7 @@
   xml:
     path: /tmp/config-{{ inventory_hostname }}.xml
     xpath: /opnsense/vlans/vlan[tag/text()="{{ item.0.tag }}"]/vlanif
-    value: "{{ opn_interfaces_vlan_parent_interface }}_vlan{{ item.0.tag }}"
+    value: "{{ item.0.vlan_parent_interface | default(opn_interfaces_vlan_parent_interface) }}_vlan{{ item.0.tag }}"
     pretty_print: yes
   with_subelements:
     - "{{ opn_vlans }}"


### PR DESCRIPTION
Using the `opn_interfaces_vlan_parent_interface` var, only one parent interface can be defined.
This PR allows to define different parent interfaces.
Example:
```
# hackish way to trigger the execution of the vlan task
opn_interfaces_vlan_parent_interface: default

opn_interfaces_specific:
  - interface: SPK8_FRONT_DC_400
    vlan: 400 
    vlan_parent_interface: em1 
    settings:
      - key: if
        value: em1
      - key: desc
        value: SRV_FRONT_400
      - key: lock
        value: 1
      - key: ipaddr
        value: 10.224.0.1
      - key: subnet
        value: 28

opn_vlans:
  - tag: 400
    vlan_parent_interface: em1
    settings:
      - key: descr
        value: "SRV_FRONT_400"
```