### PR TITLE
allow settings for dnsallowoverride and dnslocalhost

### DIFF
--- a/tasks/dnsserver.yml
+++ b/tasks/dnsserver.yml
@@ -18,4 +18,37 @@
   when: dnsservercount.count == 0
   with_items: 
     "{{ dnsserver }}"
+
+- set_fact:
+    dnsallowoverride_state: "present"
+  when: dnsallowoverride | default(True)
+- set_fact:
+    dnsallowoverride_state: "absent"
+  when: not (dnsallowoverride | default(True))
+
+- name: Set dnsallowoverride {{ dnsallowoverride_state }}
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/system/dnsallowoverride
+    state: "{{ dnsallowoverride_state }}"
+    pretty_print: yes
+
+- name: Use the local DNS service as a nameserver for this system
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/system/dnslocalhost
+    value: "1"
+    pretty_print: yes
+  when: dnslocalhost | default(True)
+
+- name: Do not use the local DNS service as a nameserver for this system
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/system/dnslocalhost
+    state: absent
+    pretty_print: yes
+  when: not (dnslocalhost | default(True))
 ...

--- a/tasks/dnsserver.yml
+++ b/tasks/dnsserver.yml
@@ -50,5 +50,5 @@
     xpath: /opnsense/system/dnslocalhost
     state: absent
     pretty_print: yes
-  when: not (dnslocalhost | default(False)
+  when: not (dnslocalhost | default(False))
 ...

--- a/tasks/dnsserver.yml
+++ b/tasks/dnsserver.yml
@@ -41,7 +41,7 @@
     xpath: /opnsense/system/dnslocalhost
     value: "1"
     pretty_print: yes
-  when: dnslocalhost | default(True)
+  when: dnslocalhost | default(False)
 
 - name: Do not use the local DNS service as a nameserver for this system
   delegate_to: localhost
@@ -50,5 +50,5 @@
     xpath: /opnsense/system/dnslocalhost
     state: absent
     pretty_print: yes
-  when: not (dnslocalhost | default(True))
+  when: not (dnslocalhost | default(False)
 ...


### PR DESCRIPTION
New PR allowing more dns related settings:
 * `dnslocalhost` : (do not) use the local DNS service as a nameserver for this system
 * `dnsallowoverride` : (do not) allow DNS server list to be overridden by DHCP/PPP on WAN