### PR TITLE
allow config of virtual IPs without vhid

### DIFF
--- a/tasks/virtualip.yml
+++ b/tasks/virtualip.yml
@@ -1,5 +1,5 @@
 ---
-- name: virtualip settings that apply to all interfaces
+- name: virtualip settings that apply to all interfaces with a vhid
   delegate_to: localhost
   xml:
     path: /tmp/config-{{ inventory_hostname }}.xml
@@ -19,5 +19,16 @@
     pretty_print: yes
   with_subelements:
     - "{{ opn_virtualip_specific | default([]) }}"
+    - settings
+
+- name: virtualip settings except CARPs
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/virtualip/vip[interface/text()="{{ item.0.interface }}" and subnet/text()="{{ item.0.subnet }}"]/{{ item.1.key }}
+    value: "{{ item.1.value }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_virtualip | default([]) }}"
     - settings
 ...


### PR DESCRIPTION
allow config of virtual IPs that do not use a vhid (IMHO only CARPs need this)
example yaml:
```ft=yaml
opn_virtualip:
  - interface: lan
    subnet: 192.168.255.9
    settings:
      - key: type
        value: single
      - key: subnet_bits
        value: 32
      - key: mode
        value: ipalias
      - key: descr
        value: LAN secondary IP
```