### PR TITLE
fix for setting <enable>0</enable> on a interface which will result in a enabled interface

### DIFF
--- a/tasks/interfaces.yml
+++ b/tasks/interfaces.yml
@@ -9,7 +9,23 @@
   with_subelements:
     - "{{ opn_interfaces_specific }}"
     - settings
-  when: opn_interfaces_specific is defined
+  when:
+    - opn_interfaces_specific is defined
+    - item.1.key != 'enable' and item.1.value != 0
+
+- name: interfaces - settings specific for disabled interfaces
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/interfaces/{{ item.0.interface }}/{{ item.1.key }}
+    state: absent
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_interfaces_specific }}"
+    - settings
+  when:
+    - opn_interfaces_specific is defined
+    - item.1.key == 'enable' and item.1.value == 0
 
 - name: interfaces - settings that apply to all interfaces
   delegate_to: localhost

--- a/tasks/interfaces.yml
+++ b/tasks/interfaces.yml
@@ -11,7 +11,21 @@
     - settings
   when:
     - opn_interfaces_specific is defined
-    - item.1.key != 'enable' and item.1.value != 0
+    - item.1.key != 'enable'
+
+- name: interfaces - settings specific for enabling interfaces
+  delegate_to: localhost
+  xml:
+    path: /tmp/config-{{ inventory_hostname }}.xml
+    xpath: /opnsense/interfaces/{{ item.0.interface }}/{{ item.1.key }}
+    value: "{{ item.1.value }}"
+    pretty_print: yes
+  with_subelements:
+    - "{{ opn_interfaces_specific }}"
+    - settings
+  when:
+    - opn_interfaces_specific is defined
+    - item.1.key == 'enable' and item.1.value == 1
 
 - name: interfaces - settings specific for disabled interfaces
   delegate_to: localhost


### PR DESCRIPTION
fix for setting 
```type=yaml
opn_interfaces_specific:
  - interface: xyz
    settings:
      - key: enabled
        value: 0
```
resulting in the xml entry
```<enable>0</enable>``` on the interface which will resulting in a interface  ... **enabled**
This PR deletes the enabled xpat if the interface is disable in the yaml.