### PR TITLE
Deescalate become from play to task level (Closes: #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ Including an example of how to use your role (for instance, with variables passe
     ---
     - hosts: firewalls
       gather_facts: false
-      become: true
+      become: false
       roles:
         - ansible-opnsense
     ...
+
+Become on play level is not needed for XML changes on localhost only for tasks to fetch/push config.xml and restart services on OPNsense.
 
 Ansible command
 ---------------

--- a/tasks/fetch.yml
+++ b/tasks/fetch.yml
@@ -1,5 +1,6 @@
 ---
 - name: fetch
+  become: yes
   fetch:
     src: /conf/config.xml
     dest: /tmp/config-{{ inventory_hostname }}.xml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -95,6 +95,7 @@
   tags: laggs
 
 - name: copy
+  become: yes
   copy:
     src: /tmp/config-{{ inventory_hostname }}.xml
     dest: /conf/config.xml
@@ -108,6 +109,7 @@
   tags: clean
 
 - name: reload
+  become: yes
   command: "{{ item }}"
   with_items:
     - configctl filter sync


### PR DESCRIPTION
Solves for us to use the role without root privileges on Ansible controller.
Goes along with gather_facts: no as this role works little different but nice.