### PR TITLE
`srm` does not exist on macOS.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -134,7 +134,12 @@
 
 - name: clean,safe delete
   delegate_to: localhost
-  shell: srm "{{ local_config_path }}"
+  shell: |
+    if which srm &>/dev/null; then
+      srm "{{ local_config_path }}"
+    else
+      rm -P "{{ local_config_path }}"
+    fi
   tags: clean
 
 - name: reload


### PR DESCRIPTION
`rm -P` overwrites the file three times before deleting.