### PR TITLE
Fix empty opn bridges

### DIFF
--- a/tasks/bridges.yml
+++ b/tasks/bridges.yml
@@ -13,11 +13,12 @@
 
 
 # remove the default empty <bridged/> node remains after configuring the first one
-
 - name: bridges - remove default empty node
   delegate_to: localhost
   xml:
     path: "{{ local_config_path }}"
     xpath: /opnsense/bridges/bridged[not(node())]
     state: absent
-  when: opn_bridges is defined
+  when:
+    - opn_bridges is defined
+    - opn_bridges | length > 0


### PR DESCRIPTION
fix handling of empty `opn_bridges` definition like:
`opn_bridges: []`